### PR TITLE
Tests coverage with Codecov ☂️

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+    env:
+      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Setup of CI with Github Actions
 - Setup of Dockerfile for local tests
 - Creation of CHANGELOG.md
-- Setup of Coverage for CI in repo (its is not executed in local tests)
+- Setup of CodeCov for CI
 
 ## [1.0.0] - 2021-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Setup of CI with Github Actions
 - Setup of Dockerfile for local tests
 - Creation of CHANGELOG.md
+- Setup of Coverage for CI in repo (its is not executed in local tests)
 
 ## [1.0.0] - 2021-04-15
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-gem "codecov", require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
+
 gemspec
 gem "codecov", require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-
 gemspec
+gem "codecov", require: false, group: :test

--- a/ms_teams.gemspec
+++ b/ms_teams.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.8"
+  spec.add_development_dependency "codecov"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "bundler/setup"
 require "ms_teams"
 require 'webmock/rspec'
 
-if ENV['CODECOV_TOKEN']
+unless ENV['CODECOV_TOKEN'].nil? || ENV['CODECOV_TOKEN'].empty?
   require 'simplecov'
   SimpleCov.start
   require 'codecov'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,13 @@ require "bundler/setup"
 require "ms_teams"
 require 'webmock/rspec'
 
+if ENV['CODECOV_TOKEN']
+  require 'simplecov'
+  SimpleCov.start
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
+
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|


### PR DESCRIPTION
Hi again, @shirts ! 😄 

I've created the skeleton for setup of Codecov in repo, to provide us the percentage of tests coverage. We can later add some badges in README.md to facilitate the view of this kind of information (for github action CI and coverage for example).

What do you think?

For this PR works well, we just have to do the following: creating an project in Codecov, related to repo, and then get the "secret" generated by codecov and register in Github repo settings as a "Repo secret" with name `CODECOV_TOKEN`. When you have time, could you do this for us (because this can only be done with administrator access)? Once made this action, the coverage will work for future commits/pull requests. We can test it in this PR, anyway, before merge 🎉  