### PR TITLE
Github actions for publish to rubygems

### DIFF
--- a/.github/workflows/publish_to_rubygems.yml
+++ b/.github/workflows/publish_to_rubygems.yml
@@ -1,0 +1,30 @@
+name: Publish to Rubygems
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Publish to Rubygems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Setup of automation for rubygems publishing
 - Setup of CI with Github Actions
 - Setup of Dockerfile for local tests
 - Creation of CHANGELOG.md


### PR DESCRIPTION
@shirts,

I created a Github Actions in order to release versions to rubygems automatically when we create a new release/tag in Github. This kind of action (creation of release) only will be made by repo admins, so this automation I belive it can be a time saver 😄  Once a release is generated in repo, by admins, the action automatically publish it to rubygems, keeping in synced source code and versions.

It is not working yet, because it is required to create a new secret in repo settings with name `RUBYGEMS_AUTH_TOKEN` with api key generated in RubyGems dashboard. Can you create it for us, please, when you have time?

Once the secret is created, we can test it creating a "official" release here in repo to execute the flow (changing version.rb + changelog.md and then creating the release).

Your thoughts/review on it will be awesome! 🕺 

🍻